### PR TITLE
Move cover page to use `.svg` rather than `.png`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 *.pdf
 test.*
 
-# Extra packages
-comments.sty
-secnum.sty
-siunitx-extra.sty
-themeta.sty
-versioning.sty
+# Ignore Extra packages
+**.sty
+**.cls
+
+# Focus on developed packages
+!uqspreamble.sty
+!uqsreport.cls

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 # Ignore output files
 *.pdf
 test.*
+
+# Extra packages
+comments.sty
+secnum.sty
+siunitx-extra.sty
+themeta.sty
+versioning.sty

--- a/uqspreamble.sty
+++ b/uqspreamble.sty
@@ -112,6 +112,7 @@
 \usepackage { graphicx    }
 \usepackage { tikz        }
 \usepackage { tikz-3dplot }
+\usepackage { svg         }
 
 \usepackage { float      }
 \usepackage [ export ]{ adjustbox  }

--- a/uqsreport.cls
+++ b/uqsreport.cls
@@ -237,7 +237,7 @@
   \begin{tikzpicture}[remember~picture,overlay]
 
     \node( starmap ) at ([ yshift=40mm ] current~page . center ) {
-      \includegraphics[ width=\paperwidth ]{ images/starmap.png }
+      \includesvg[ width=\paperwidth, inkscapearea=page ]{ images/starmap.svg }
     };
 
     \node[ anchor=north ] at ([ shift={(-3mm,-10mm)} ] current~page . north) {


### PR DESCRIPTION
Change the cover page to use the scalable vector graphics (`.svg`) files generated by the [star-cover](https://github.com/uqspace/star-cover) project, rather than fixed resolution `.png` files. 
The new `.svg` files increase the professional appearance of the report, and have a wider field of view which correctly spans the cover page.